### PR TITLE
fixed missing 'var' keyword.

### DIFF
--- a/lib/connect_ltsv_logger.js
+++ b/lib/connect_ltsv_logger.js
@@ -151,8 +151,8 @@ function setFormat(arr){
 }
 
 exports = module.exports = function ltsvLogger(options){
-  toString = Object.prototype.toString;
-  typeOf = function(that){
+  var toString = Object.prototype.toString;
+  var typeOf = function(that){
     var t = toString.call(that);
     return t.split(" ")[1].replace("]","");
   };


### PR DESCRIPTION
This causes "global leak" in tests.
I found this error at my Application test.

  1) server #server running:
     Error: global leaks detected: toString, typeOf
      at Runner.checkGlobals (/usr/local/lib/node_modules/mocha/lib/runner.js:167:21)
      at Runner.<anonymous> (/usr/local/lib/node_modules/mocha/lib/runner.js:58:44)
      at Runner.EventEmitter.emit (events.js:115:20)
      at Runner.runTests.next (/usr/local/lib/node_modules/mocha/lib/runner.js:400:14)
      at Test.Runnable.run (/usr/local/lib/node_modules/mocha/lib/runnable.js:215:5)
      at Runner.runTest (/usr/local/lib/node_modules/mocha/lib/runner.js:343:10)
      at Runner.runTests.next (/usr/local/lib/node_modules/mocha/lib/runner.js:389:12)
      at next (/usr/local/lib/node_modules/mocha/lib/runner.js:269:14)
      at Runner.hooks (/usr/local/lib/node_modules/mocha/lib/runner.js:278:7)
      at next (/usr/local/lib/node_modules/mocha/lib/runner.js:226:23)
      at Runner.hook (/usr/local/lib/node_modules/mocha/lib/runner.js:246:5)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)
